### PR TITLE
Switch from y_hooks to ALS for crucial hooks

### DIFF
--- a/container.inc
+++ b/container.inc
@@ -639,7 +639,7 @@ public OnItemDestroy(Item:itemid)
 		#if defined SS_OnItemDestroy
 				SS_OnItemDestroy(itemid);
 		#endif
-		return 0;
+		return;
 }
 #if defined _ALS_OnItemDestroy
 		#undef OnItemDestroy
@@ -660,7 +660,7 @@ public OnItemCreateInWorld(Item:itemid)
 		#if defined SS_OnItemCreateInWorld
 				SS_OnItemCreateInWorld(itemid);
 		#endif
-		return 1;
+		return;
 }
 #if defined _ALS_OnItemCreateInWorld
 		#undef OnItemCreateInWorld

--- a/container.inc
+++ b/container.inc
@@ -631,18 +631,47 @@ stock GetItemContainerSlot(Item:itemid, &slot) {
 
 ==============================================================================*/
 
+public OnItemDestroy(Item:itemid)
+{
+		if(cnt_ItemContainer[itemid] != INVALID_CONTAINER_ID) {
+			RemoveItemFromContainer(cnt_ItemContainer[itemid], cnt_ItemContainerSlot[itemid]);
+		}
+		#if defined SS_OnItemDestroy
+				SS_OnItemDestroy(itemid);
+		#endif
+		return 0;
+}
+#if defined _ALS_OnItemDestroy
+		#undef OnItemDestroy
+#else
+		#define _ALS_OnItemDestroy
+#endif
+#define OnItemDestroy SS_OnItemDestroy
+#if defined SS_OnItemDestroy
+		forward SS_OnItemDestroy(Item:itemid);
+#endif
 
-hook OnItemDestroy(Item:itemid) {
+
+public OnItemCreateInWorld(Item:itemid)
+{
 	if(cnt_ItemContainer[itemid] != INVALID_CONTAINER_ID) {
 		RemoveItemFromContainer(cnt_ItemContainer[itemid], cnt_ItemContainerSlot[itemid]);
 	}
+		#if defined SS_OnItemCreateInWorld
+				SS_OnItemCreateInWorld(itemid);
+		#endif
+		return 1;
 }
+#if defined _ALS_OnItemCreateInWorld
+		#undef OnItemCreateInWorld
+#else
+		#define _ALS_OnItemCreateInWorld
+#endif
+#define OnItemCreateInWorld SS_OnItemCreateInWorld
+#if defined SS_OnItemCreateInWorld
+		forward SS_OnItemCreateInWorld(Item:itemid);
+#endif
 
-hook OnItemCreateInWorld(Item:itemid) {
-	if(cnt_ItemContainer[itemid] != INVALID_CONTAINER_ID) {
-		RemoveItemFromContainer(cnt_ItemContainer[itemid], cnt_ItemContainerSlot[itemid]);
-	}
-}
 
 hook OnItemCreate(Item:itemid) {
 	cnt_ItemContainer[itemid] = INVALID_CONTAINER_ID;


### PR DESCRIPTION
Using the ALS hooking method works out better in certain situation, since ALS hooks get executed after ysi hooks.

Let's assume you have a gps item on your server that lets you access the map as long as you have it in your inventory.
In the current implementation, you'd have to save yourself whether a player has a gps, how many of them he's got and if the one being destroyed is his last one.

It'd be simpler, we we were able to hook onto `OnItemDestroy` (at this time the item still exists, so it makes sense to be able to access all its data) and check if it's in a player's inventory. If it is, check how many GPS devices he's got and hide the map if it was his last one.

In terms of code it'd look like this:
```pawn
hook OnItemDestroy(Item:itemid) {
    if (GetItemType(itemid) != item_Gps ) {
        return;
    }

    new playerid = INVALID_PLAYER_ID;
    GetItemInventoryPlayer(itemid, playerid);

    if (playerid == INVALID_PLAYER_ID) {
        return;
    }
    
    // Loop through inventory items and see if more than 1 gps exists
    if (GetPlayerItemCount(playerid, item_Gps) > 1 ) {
        return;
    }

    ToggleMapForPlayer(playerid, false); 
}
```

Another solution would be to force different execution of YSI's hooks but it also might cause issues elsewhere - other libraries, existing developer's code, etc.

This change shouldn't break anything, we just give developer's access to data that should still be accessible at this point.
There's also `OnItemDestroyed` for whenever our item really gets destroyed and all its data should be gone indeed. 